### PR TITLE
update lwip to 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sprity"
   ],
   "dependencies": {
-    "lwip": "0.0.6",
+    "lwip": "0.0.7",
     "bluebird": "^2.9.24"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm using iojs (v2.0.1), and encountered an error when installing sprity:

```
npm WARN package.json zoubin@1.0.0 No repository field.
/
> lwip@0.0.6 install /Users/zoubin/usr/src/zoubin/npm-use/node_modules/sprity/node_modules/sprity-lwip/node_modules/lwip
> node-gyp rebuild

  CXX(target) Release/obj.target/lwip_decoder/src/decoder/init.o
In file included from ../src/decoder/init.cpp:1:
In file included from ../src/decoder/decoder.h:13:
../node_modules/nan/nan.h:207:68: error: too many arguments to function call, expected at most 2, have 4
    return v8::Signature::New(v8::Isolate::GetCurrent(), receiver, argc, argv);
           ~~~~~~~~~~~~~~~~~~                                      ^~~~~~~~~~
/Users/zoubin/.node-gyp/2.0.1/deps/v8/include/v8.h:4188:3: note: 'New' declared here
```

It seems that the problem is caused by lwip. There were issues about this (https://github.com/EyalAr/lwip/pull/142, https://github.com/EyalAr/lwip/pull/147). This problem has been fixed in lwip@0.0.7. 

I have run the tests, and everything is OK. And I have installed it succesfully.
