### PR TITLE
Node 4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sprity"
   ],
   "dependencies": {
-    "lwip": "0.0.7",
+    "lwip": "0.0.8",
     "bluebird": "^2.9.24"
   },
   "devDependencies": {


### PR DESCRIPTION
lwip with Node 4 support has been released as 0.0.8
