### PR TITLE
Upgrading lwip version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ node_js:
 - '0.10'
 - '0.12'
 - '4'
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 notifications:
   slack:
     secure: DO5e6xyMlQUzwZqbBYipdnu46yjnINDclux0H+cjlmbGCyLr+SXEhQJzdeapm80TJtwaR/bVhoET+1MWQaOjtnjAms6payQAilea0mEPhQdkR1+i4ZV76Kp/4EjnkWs38x5DlJKbUm34M2y3qRQ0hdqyVQExnR84xTZyywbx+aM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '0.10'
 - '0.12'
-- '4.1.2'
+- '4'
 notifications:
   slack:
     secure: DO5e6xyMlQUzwZqbBYipdnu46yjnINDclux0H+cjlmbGCyLr+SXEhQJzdeapm80TJtwaR/bVhoET+1MWQaOjtnjAms6payQAilea0mEPhQdkR1+i4ZV76Kp/4EjnkWs38x5DlJKbUm34M2y3qRQ0hdqyVQExnR84xTZyywbx+aM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '0.10'
 - '0.12'
-- 'iojs'
+- '4.1.2'
 notifications:
   slack:
     secure: DO5e6xyMlQUzwZqbBYipdnu46yjnINDclux0H+cjlmbGCyLr+SXEhQJzdeapm80TJtwaR/bVhoET+1MWQaOjtnjAms6payQAilea0mEPhQdkR1+i4ZV76Kp/4EjnkWs38x5DlJKbUm34M2y3qRQ0hdqyVQExnR84xTZyywbx+aM=

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sprity"
   ],
   "dependencies": {
-    "lwip": "0.0.7",
+    "lwip": "0.0.8",
     "bluebird": "^2.9.24"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey,

As lwip 0.0.7 doesn’t install with Node 4, but the 0.0.8 does, I tried to upgrade its version, and all the tests are green.

```
sprity-lwip
    ✓ should return a png image buffer (82ms)
    ✓ should return a jpg image buffer (42ms)
    ✓ should return a gif image buffer (47ms)


  3 passing (180ms)
```

Can you give it a go ?
