### PR TITLE
bumps lwip version to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sprity"
   ],
   "dependencies": {
-    "lwip": "0.0.8",
+    "lwip": "0.0.9",
     "bluebird": "^2.9.24"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes issues with node v6+. #7 

See PR [#250 on lwip](https://github.com/EyalAr/lwip/pull/250)
